### PR TITLE
OpenUri() should work with empty tracklist

### DIFF
--- a/mopidy_mpris/objects.py
+++ b/mopidy_mpris/objects.py
@@ -261,10 +261,10 @@ class MprisObject(dbus.service.Object):
     @dbus.service.method(dbus_interface=PLAYER_IFACE)
     def OpenUri(self, uri):
         logger.debug('%s.OpenUri called', PLAYER_IFACE)
-        if not self.get_CanPlay():
+        if not self.get_CanControl():
             # NOTE The spec does not explictly require this check, but guarding
             # the other methods doesn't help much if OpenUri is open for use.
-            logger.debug('%s.Play not allowed', PLAYER_IFACE)
+            logger.debug('%s.OpenUri not allowed', PLAYER_IFACE)
             return
         # NOTE Check if URI has MIME type known to the backend, if MIME support
         # is added to the backend.

--- a/tests/test_player_interface.py
+++ b/tests/test_player_interface.py
@@ -806,8 +806,8 @@ class PlayerInterfaceTest(unittest.TestCase):
         self.assertEqual(self.core.playback.state.get(), PLAYING)
         self.assertEqual(self.core.playback.current_track.get().uri, 'dummy:a')
 
-    def test_open_uri_is_ignored_if_can_play_is_false(self):
-        self.mpris.get_CanPlay = lambda *_: False
+    def test_open_uri_is_ignored_if_can_control_is_false(self):
+        self.mpris.get_CanControl = lambda *_: False
         self.backend.library.dummy_library = [
             Track(uri='dummy:/test/uri')]
         self.mpris.OpenUri('dummy:/test/uri')


### PR DESCRIPTION
When mopidy is started clean, there is no tracklist or playlist and `OpenUri()` does not work at all.

These commits guard `OpenUri()` with `CanControl` instead of `CanPlay`. The [MPRIS2 specification](http://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanPlay) states that `CanPlay` only indicates if the `Play()` or `PlayPause()` methods can be used.
