### PR TITLE
Add config option to use the system bus.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,10 +55,17 @@ Configuration
 
 There's no configuration needed for the MPRIS extension to work.
 
+If Mopidy is running as an user without an X display, Mopidy-MPRIS will fail by
+default. To fix this, the config option ``system_bus`` can be set to ``true``,
+this will lead to Mopidy-MPRIS making itself available on the system bus. Few
+MPRIS clients will try to access MPRIS devices on the system bus.
+
 The following configuration values are available:
 
 - ``mpris/enabled``: If the MPRIS extension should be enabled or not.
 - ``mpris/desktop_file``: Path to Mopidy's ``.desktop`` file.
+- ``mpris/system_bus``: If Mopidy-MPRIS should connect to the system bus
+                        instead of the session bus.
 
 
 Usage

--- a/mopidy_mpris/__init__.py
+++ b/mopidy_mpris/__init__.py
@@ -21,13 +21,10 @@ class Extension(ext.Extension):
     def get_config_schema(self):
         schema = super(Extension, self).get_config_schema()
         schema['desktop_file'] = config.Path()
+        schema['system_bus'] = config.Boolean()
         return schema
 
     def validate_environment(self):
-        if 'DISPLAY' not in os.environ:
-            raise exceptions.ExtensionError(
-                'An X11 $DISPLAY is needed to use D-Bus')
-
         try:
             import dbus  # noqa
         except ImportError as e:

--- a/mopidy_mpris/ext.conf
+++ b/mopidy_mpris/ext.conf
@@ -1,3 +1,4 @@
 [mpris]
 enabled = true
 desktop_file = /usr/share/applications/mopidy.desktop
+system_bus = false

--- a/mopidy_mpris/objects.py
+++ b/mopidy_mpris/objects.py
@@ -80,7 +80,10 @@ class MprisObject(dbus.service.Object):
 
     def _connect_to_dbus(self):
         logger.debug('Connecting to D-Bus...')
-        bus_name = dbus.service.BusName(BUS_NAME, dbus.SessionBus())
+        if (self.config['mpris']['system_bus']):
+            bus_name = dbus.service.BusName(BUS_NAME, dbus.SystemBus())
+        else:
+            bus_name = dbus.service.BusName(BUS_NAME, dbus.SessionBus())
         logger.info('MPRIS server connected to D-Bus')
         return bus_name
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -13,6 +13,7 @@ class ExtensionTest(unittest.TestCase):
 
         self.assertIn('[mpris]', config)
         self.assertIn('enabled = true', config)
+        self.assertIn('system_bus = false', config)
 
     def test_get_config_schema(self):
         ext = Extension()
@@ -20,6 +21,7 @@ class ExtensionTest(unittest.TestCase):
         schema = ext.get_config_schema()
 
         self.assertIn('desktop_file', schema)
+        self.assertIn('system_bus', schema)
 
     def test_get_frontend_classes(self):
         ext = Extension()


### PR DESCRIPTION
This commit adds a config option to use the system bus instead of the session bus. This change makes it possible to expose Mopidy through an MPRIS interface even when it's run in its own user without a session bus.

This commit relates closely to issue #9, and might solve it as far as possible within the scope of this extension.

The check for whether the `$DISPLAY` X11 environment variable is set is removed from the `validate_environment(self)` method in the main Extension class. Dbus will take care of this error, and there is already logic to handle it in the code that deals with dbus. the error will now be printed like this:

    WARNING  MPRIS frontend setup failed (org.freedesktop.DBus.Error.NotSupported: Unable to autolaunch a dbus-daemon without a $DISPLAY for X11)

This error message is equally verbose and easy to spot.