### PR TITLE
Hardcode supported mime types 

### DIFF
--- a/mopidy_mpris/objects.py
+++ b/mopidy_mpris/objects.py
@@ -49,7 +49,15 @@ class MprisObject(dbus.service.Object):
             'SupportedUriSchemes': (self.get_SupportedUriSchemes, None),
             # NOTE Return MIME types supported by local backend if support for
             # reporting supported MIME types is added
-            'SupportedMimeTypes': (dbus.Array([], signature='s'), None),
+            'SupportedMimeTypes': (dbus.Array([
+                dbus.String(u'audio/mpeg'),
+                dbus.String(u'audio/x-ms-wma'),
+                dbus.String(u'audio/x-ms-asf'),
+                dbus.String(u'audio/x-flac'),
+                dbus.String(u'audio/flac'),
+                dbus.String(u'audio/l16;channels=2;rate=44100'),
+                dbus.String(u'audio/l16;rate=44100;channels=2')
+                ], signature='s'), None),
         }
 
     def _get_player_iface_properties(self):

--- a/mopidy_mpris/objects.py
+++ b/mopidy_mpris/objects.py
@@ -50,13 +50,13 @@ class MprisObject(dbus.service.Object):
             # NOTE Return MIME types supported by local backend if support for
             # reporting supported MIME types is added
             'SupportedMimeTypes': (dbus.Array([
-                dbus.String(u'audio/mpeg'),
-                dbus.String(u'audio/x-ms-wma'),
-                dbus.String(u'audio/x-ms-asf'),
-                dbus.String(u'audio/x-flac'),
-                dbus.String(u'audio/flac'),
-                dbus.String(u'audio/l16;channels=2;rate=44100'),
-                dbus.String(u'audio/l16;rate=44100;channels=2')
+                dbus.String('audio/mpeg'),
+                dbus.String('audio/x-ms-wma'),
+                dbus.String('audio/x-ms-asf'),
+                dbus.String('audio/x-flac'),
+                dbus.String('audio/flac'),
+                dbus.String('audio/l16;channels=2;rate=44100'),
+                dbus.String('audio/l16;rate=44100;channels=2')
                 ], signature='s'), None),
         }
 

--- a/tests/test_root_interface.py
+++ b/tests/test_root_interface.py
@@ -84,4 +84,4 @@ class RootInterfaceTest(unittest.TestCase):
 
     def test_supported_mime_types_is_empty(self):
         result = self.mpris.Get(objects.ROOT_IFACE, 'SupportedMimeTypes')
-        self.assertEquals(len(result), 0)
+        self.assertGreater(len(result), 0)


### PR DESCRIPTION
It will enable mopidy to play audio through upnp dlna when using rygel + mopidy-mpris

Temporary solution untill issue mopidy/mopidy#812 is done.