### PR TITLE
Fix crash for images with width None

### DIFF
--- a/mopidy_mpris/player.py
+++ b/mopidy_mpris/player.py
@@ -274,7 +274,7 @@ class Player(Interface):
         images = self.core.library.get_images([track.uri]).get()
         if images[track.uri]:
             largest_image = sorted(
-                images[track.uri], key=lambda i: i.width, reverse=True
+                images[track.uri], key=lambda i: i.width or 0, reverse=True
             )[0]
             return largest_image.uri
 

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -180,6 +180,7 @@ def test_get_metadata_use_library_image_as_art_url(backend, core, player):
         "dummy:a": [
             Image(uri="http://example.com/small.jpg", width=100, height=100),
             Image(uri="http://example.com/large.jpg", width=200, height=200),
+            Image(uri="http://example.com/unsized.jpg"),
         ],
     }
     core.tracklist.add([Track(uri="dummy:a")])


### PR DESCRIPTION
When using mopidy-mpris and mopidy-youtube at the same time, I came
across the following crash:

    ERROR    2020-06-07 12:52:04,524 [1975575:MainThread] pydbus.registration
      Exception while handling org.freedesktop.DBus.Properties.GetAll()
    Traceback (most recent call last):
      File "/usr/lib/python3.8/site-packages/pydbus/registration.py", line 81, in call_method
        result = method(*parameters, **kwargs)
      File "/usr/lib/python3.8/site-packages/pydbus/registration.py", line 110, in GetAll
        ret[local] = GLib.Variant(type, getattr(self.object, local))
      File "/usr/lib/python3.8/site-packages/mopidy_mpris/player.py", line 264, in Metadata
        art_url = self._get_art_url(track)
      File "/usr/lib/python3.8/site-packages/mopidy_mpris/player.py", line 276, in _get_art_url
        largest_image = sorted(
    TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'