### PR TITLE
make type spec more correct

### DIFF
--- a/src/mopidy_mpris/playlists.py
+++ b/src/mopidy_mpris/playlists.py
@@ -31,7 +31,7 @@ class Playlists(Interface):
           <arg name="Playlists" type="a(oss)" direction="out"/>
         </method>
         <signal name="PlaylistChanged">
-          <arg name="Playlist" type="oss"/>
+          <arg name="Playlist" type="(oss)"/>
         </signal>
         <property name="PlaylistCount" type="u" access="read"/>
         <property name="Orderings" type="as" access="read"/>


### PR DESCRIPTION
The type specified contained (according to dbus spec) an invalid string, some clients like dbus2mqtt interpret this as 3 separate types and crash.
The correct way is to use a struct, which is represented as a tuple in python.